### PR TITLE
Handle python 3 encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='tasktiger-admin',
-    version='0.2.2',
+    version='0.2.3',
     url='http://github.com/closeio/tasktiger-admin',
     license='MIT',
     description='Admin for tasktiger, a Python task queue',

--- a/tasktiger_admin/utils.py
+++ b/tasktiger_admin/utils.py
@@ -1,9 +1,13 @@
+import sys
 import click
 from flask import Flask
 from flask_admin import Admin
 import redis
 from tasktiger import TaskTiger
 from tasktiger_admin import TaskTigerView
+
+PY2 = sys.version_info[0] == 2
+
 
 @click.command()
 @click.option('-h', '--host', help='Redis server hostname')
@@ -12,7 +16,8 @@ from tasktiger_admin import TaskTigerView
 @click.option('-n', '--db', help='Redis database number')
 @click.option('-l', '--listen', help='Admin port to listen on')
 def run_admin(host, port, db, password, listen):
-    conn = redis.Redis(host, int(port or 6379), int(db or 0), password)
+    decode_responses = not PY2
+    conn = redis.Redis(host, int(port or 6379), int(db or 0), password, decode_responses=decode_responses)
     tiger = TaskTiger(setup_structlog=True, connection=conn)
     app = Flask(__name__)
     admin = Admin(app, url='/')


### PR DESCRIPTION
Prior to this PR, running tasktiger-admin on python 3 results in `TypeError` because `decode_responses` is not set to `True`.

    TypeError: sequence item 2: expected str instance, bytes found

 P.S. Thanks for making an awesome task framework, way to go close.io!