### PR TITLE
Add integration links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.pyc
+.DS_Store
+build/
+dist/
+*.egg-info/
+.tox/
+.idea/
+venv/

--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,26 @@ details).
 For a more advanced integration, *tasktiger-admin* can be integrated in a Flask
 app with an existing flask-admin by using the provided view in
 ``tasktiger_admin.views.TaskTigerView``.
+
+
+Integration Links
+-----------------
+The ``TaskTigerView`` class takes an optional ``integration_config`` parameter
+that can be used to render integration links on the admin Task Detail page.
+These can be used to easily navigate to external resources like logging
+infrastructure or a Wiki. ``integration_config`` should be a list of tuples
+that specify the integration name and URL template.
+
+The URL template supports three variables:
+
+* ``task_id``: Current task id
+* ``execution_start``: Execution start time minus a 10 second buffer
+* ``execution_failed``: Execution failed time plus a 10 second buffer
+
+Example integration config that points to a logging website.
+.. code:: python
+
+  integration_config = [('Logs', 'https://logs.example.com/search/?'
+                                 'task_id={{ task_id }}&'
+                                 'start_time={{ execution_start }}&'
+                                 'end_time={{ execution_failed }}')]

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,7 @@ The URL template supports three variables:
 * ``execution_failed``: Execution failed time plus a 10 second buffer
 
 Example integration config that points to a logging website.
+
 .. code:: python
 
   integration_config = [('Logs', 'https://logs.example.com/search/?'

--- a/tasktiger_admin/integrations.py
+++ b/tasktiger_admin/integrations.py
@@ -25,6 +25,17 @@ def _get_time(time_string, delta):
 
 
 def generate_integrations(integration_templates, task, execution):
+    """
+    Generate integration URLs.
+
+    Args:
+        task: TaskTiger task
+        execution: Task execution dictionary
+        integration_templates: List of integration templates
+
+    Returns:
+        list: List of tuples containing integration name and URL
+    """
     integrations = []
     for name, url_template in integration_templates:
         url_template = jinja2.Template(url_template)

--- a/tasktiger_admin/integrations.py
+++ b/tasktiger_admin/integrations.py
@@ -1,0 +1,33 @@
+import datetime
+
+import jinja2
+
+TIME_BUFFER = 10  # Number of seconds to buffer start/end times
+
+
+def _get_template_vars(task, execution):
+    info = {}
+    if task:
+        info['task_id'] = task.id
+
+    if execution:
+        info['execution_start'] = _get_time(execution['time_started'],
+                                            -TIME_BUFFER)
+        info['execution_failed'] = _get_time(execution['time_failed'],
+                                             TIME_BUFFER)
+
+    return info
+
+
+def _get_time(time_string, delta):
+    execution_time = datetime.datetime.utcfromtimestamp(int(time_string) + delta)
+    return execution_time.isoformat()
+
+
+def generate_integrations(integration_templates, task, execution):
+    integrations = []
+    for name, url_template in integration_templates:
+        url_template = jinja2.Template(url_template)
+        url = url_template.render(**_get_template_vars(task, execution))
+        integrations.append((name, url))
+    return integrations

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -8,7 +8,7 @@
     <p>Links:</p>
     <ul>
     {% for name, url in integrations %}
-        <li><a href="{{ url }}">{{ name }}</a> </li>
+        <li><a href="{{ url }}">{{ name }}</a></li>
     {% endfor %}
     </ul>
 {% endif %}
@@ -26,7 +26,7 @@
             {% if execution_integrations %}
                 <ul>
                 {% for name, url in execution_integrations %}
-                    <li><a href="{{ url }}">{{ name }}</a> </li>
+                    <li><a href="{{ url }}">{{ name }}</a></li>
                 {% endfor %}
                 </ul>
             {% endif %}

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -4,19 +4,32 @@
 <h2><a href="../../../">TaskTiger</a> – <a href="../">{{ queue }} ({{ state }})</a></h2>
 
 <pre>{{ task_dumped }}</pre>
-
+{% if integrations %}
+    <p>Links:</p>
+    <ul>
+    {% for name, url in integrations %}
+        <li><a href="{{ url }}">{{ name }}</a> </li>
+    {% endfor %}
+    </ul>
+{% endif %}
 {% if executions_dumped %}
 <p>Executions:</p>
 
     <ul>
 
-        {% for execution_dumped, traceback in executions_dumped %}
+        {% for execution_dumped, traceback, execution_integrations in executions_dumped %}
 
         <li><pre>{{ execution_dumped }}
 
 {{ traceback }}</pre>
         </li>
-
+            {% if execution_integrations %}
+                <ul>
+                {% for name, url in execution_integrations %}
+                    <li><a href="{{ url }}">{{ name }}</a> </li>
+                {% endfor %}
+                </ul>
+            {% endif %}
         {% endfor %}
 
     </ul>

--- a/tasktiger_admin/views.py
+++ b/tasktiger_admin/views.py
@@ -9,6 +9,13 @@ from .integrations import generate_integrations
 
 class TaskTigerView(BaseView):
     def __init__(self, tiger, integration_config=None, *args, **kwargs):
+        """
+        TaskTiger admin view.
+
+        Args:
+            tiger: TaskTiger instance
+            integration_config: List of tuples containing integration name and URL
+        """
         super(TaskTigerView, self).__init__(*args, **kwargs)
         self.tiger = tiger
         self.integration_config = integration_config


### PR DESCRIPTION
Add integration links to task detail page that allow you to link to logging infrastructure, runbooks, etc.  Templating allows injection of task id and execution start/failed times into URL.