### PR TITLE
Add a JS filter to tasktiger.html to easily filter for queue names that contain a specific string

### DIFF
--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
@@ -1,5 +1,5 @@
 {% extends 'admin/index.html' %}
-{% import 'admin/static.html' as admin_static with context%}
+{% import 'admin/static.html' as admin_static with context %}
 {% block body %}
 
 <h2>TaskTiger</h2>
@@ -11,7 +11,7 @@
    </div>
  {% endblock %}
 
-<table class="metrics table table-striped table-bordered searchable">
+<table class="metrics table table-striped table-bordered">
     <thead>
         <tr>
             <th></th>
@@ -21,7 +21,7 @@
             <th>Error</th>
         </tr>
     </thead>
-    <tbody>
+    <tbody class="searchable">
 {% for group_name, group_stats, queue_stats in queue_stats_groups %}
     {% if queue_stats|length > 1 %}
         <tr>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
@@ -51,3 +51,7 @@
 </table>
 
 {% endblock %}
+
+{% block tail %}
+  <script src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
+{% endblock %}

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger.html
@@ -1,9 +1,17 @@
 {% extends 'admin/index.html' %}
+{% import 'admin/static.html' as admin_static with context%}
 {% block body %}
 
 <h2>TaskTiger</h2>
 
-<table class="metrics table table-striped table-bordered">
+{% block details_search %}
+   <div class="input-group fa_filter_container col-lg-6">
+     <span class="input-group-addon">{{ _gettext('Filter') }}</span>
+     <input id="fa_filter" type="text" class="form-control">
+   </div>
+ {% endblock %}
+
+<table class="metrics table table-striped table-bordered searchable">
     <thead>
         <tr>
             <th></th>


### PR DESCRIPTION
This PR adds a Filter textbox to `tasktiger.html` based on the `details_search` functionality in flask-admin to allow us to easily filter a large list of Tasktiger queues by queue name. 

Here's a gif of the filter in action: 
![tasktiger_filter](https://user-images.githubusercontent.com/2817521/78308307-25ac4a80-7516-11ea-85c0-fe39e4b61c2c.gif)
