### PR TITLE
Make it run in virtual environments with redis-py 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,17 +69,17 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.6
-    - image: redis:4.0.6
+    - image: redis:6.2.0
 
   test-3.7:
     <<: *defaults
     docker:
     - image: circleci/python:3.7
-    - image: redis:4.0.6
+    - image: redis:6.2.0
 
   test-3.8:
     <<: *defaults
     docker:
     - image: circleci/python:3.8
-    - image: redis:4.0.6
+    - image: redis:6.2.0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   redis:
-    image: redis:4.0.6
+    image: redis:6.2.0
     expose:
       - 6379
   shell:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,13 +22,13 @@ poetry==0.12.17
 pylev==1.3.0
 pyparsing==2.4.2
 pyrsistent==0.14.11
-redis==2.10.6
+redis==3.5.3
 requests==2.22.0
 requests-toolbelt==0.8.0
 shellingham==1.3.1
 six==1.12.0
 structlog==20.2.0
-tasktiger==0.10.1
+tasktiger==0.11
 tomlkit==0.5.5
 urllib3==1.25.6
 virtualenv==16.7.5

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setup(
     install_requires=[
         'click',
         'flask-admin',
-        'redis>=2,<3',
+        'redis>=2,<4',
         'structlog',
-        'tasktiger>=0.10.1',
+        'tasktiger>=0.11',
     ],
     packages=['tasktiger_admin'],
     entry_points={


### PR DESCRIPTION
All it does is it allows this project to run in an environment with redis-py 3. The only place this project uses Redis is in [this line](https://github.com/closeio/tasktiger-admin/blob/master/tasktiger_admin/utils.py#L16). This basically means it will use whatever version is installed in the current environment and, as long as TaskTiger can use it, all should be fine.

My plan is to come back here later in the cycle when working on TaskTiger itself to drop support for redis-py 2 and also drop it here and update the TaskTiger dependency version.