### PR TITLE
Nicer task detail page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ requests-toolbelt==0.8.0
 shellingham==1.3.1
 six==1.12.0
 structlog==20.2.0
-tasktiger==0.11
+-e git+ssh://git@github.com/closeio/tasktiger.git@6731b65f54a934980322b5819c33071a40cf4f72#egg=tasktiger
 tomlkit==0.5.5
 urllib3==1.25.6
 virtualenv==16.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ requests-toolbelt==0.8.0
 shellingham==1.3.1
 six==1.12.0
 structlog==20.2.0
--e git+ssh://git@github.com/closeio/tasktiger.git@951a2fc12678a0de8f34659dcca8806bb6250e2f#egg=tasktiger
+git+ssh://git@github.com/closeio/tasktiger.git@951a2fc12678a0de8f34659dcca8806bb6250e2f#egg=tasktiger
 tomlkit==0.5.5
 urllib3==1.25.6
 virtualenv==16.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ requests-toolbelt==0.8.0
 shellingham==1.3.1
 six==1.12.0
 structlog==20.2.0
-git+ssh://git@github.com/closeio/tasktiger.git@951a2fc12678a0de8f34659dcca8806bb6250e2f#egg=tasktiger
+tasktiger==0.14
 tomlkit==0.5.5
 urllib3==1.25.6
 virtualenv==16.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ requests-toolbelt==0.8.0
 shellingham==1.3.1
 six==1.12.0
 structlog==20.2.0
--e git+ssh://git@github.com/closeio/tasktiger.git@6731b65f54a934980322b5819c33071a40cf4f72#egg=tasktiger
+-e git+ssh://git@github.com/closeio/tasktiger.git@951a2fc12678a0de8f34659dcca8806bb6250e2f#egg=tasktiger
 tomlkit==0.5.5
 urllib3==1.25.6
 virtualenv==16.7.5

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -17,27 +17,27 @@
     <table class="metrics table table-striped table-bordered">
         <tbody>
         <tr>
-            <th>id</th>
+            <th>ID</th>
             <td>{{ task_data.id }}</td>
         </tr>
         <tr>
-            <th>func</th>
+            <th>Func</th>
             <td>{{ task_data.func }}</td>
         </tr>
         <tr>
-            <th>args</th>
+            <th>Args</th>
             <td>{{ task_data.args }}</td>
         </tr>
         <tr>
-            <th>kwargs</th>
+            <th>Kwargs</th>
             <td>{{ task_data.kwargs }}</td>
         </tr>
         <tr>
-            <th>time last queued</th>
+            <th>Time Last Queued</th>
             <td>{{ task_data.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>
         <tr>
-            <th>dump</th>
+            <th>Dump</th>
             <td>
                 <details>
                     <summary>Show/Hide</summary>
@@ -63,27 +63,28 @@
             <table class="metrics table table-striped table-bordered">
                 <tbody>
                 <tr>
-                    <th>exception name</th>
+                    <th>Exception Name</th>
                     <td>{{ execution.exception_name }}</td>
                 </tr>
                 <tr>
-                    <th>host</th>
+                    <th>Host</th>
                     <td>{{ execution.host }}</td>
                 </tr>
                 <tr>
-                    <th>success</th>
+                    <th>Success</th>
                     <td>{{ execution.success }}</td>
                 </tr>
                 <tr>
-                    <th>time failed</th>
+                    <th>Time Failed</th>
                     <td>{{ execution.time_failed.strftime("%Y-%m-%d %H:%M:%S") }}</td>
                 </tr>
                 <tr>
-                    <th>time started</th>
+                    <th>Time Started</th>
                     <td>{{ execution.time_started.strftime("%Y-%m-%d %H:%M:%S") }}</td>
                 </tr>
+                {% if execution_integrations %}
                 <tr>
-                    <th>execution integrations</th>
+                    <th>Execution Integrations</th>
                     <td>
                         <ul>
                             {% for name, url in execution_integrations %}
@@ -92,10 +93,15 @@
                         </ul>
                     </td>
                 </tr>
+                {% endif %}
                 <tr>
-                    <th>traceback</th>
+                    <th>Traceback</th>
                     <td>
+                        {% if loop.first %}
+                        <details open>
+                        {% else %}
                         <details>
+                        {% endif %}
                             <summary>Show/Hide</summary>
                             <div>
                                 <pre>{{ traceback }}</pre>
@@ -104,7 +110,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>dump</th>
+                    <th>Dump</th>
                     <td>
                         <details>
                             <summary>Show/Hide</summary>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -5,7 +5,11 @@
     <style type="text/css">
         th {
             width: 1px;
-            white-space: nowrap
+            white-space: nowrap;
+        }
+
+        summary {
+            cursor: pointer;
         }
     </style>
 {% endblock %}
@@ -39,16 +43,16 @@
             </tr>
         {% endif %}
         {% if "unique" in task_data %}
-        <tr>
-            <th>Unique</th>
-            <td>{{ task_data.unique}}</td>
-        </tr>
+            <tr>
+                <th>Unique</th>
+                <td>{{ task_data.unique }}</td>
+            </tr>
         {% endif %}
         {% if "unique_key" in task_data %}
-        <tr>
-            <th>Unique Key</th>
-            <td>{{ task_data.unique_key}}</td>
-        </tr>
+            <tr>
+                <th>Unique Key</th>
+                <td>{{ task_data.unique_key }}</td>
+            </tr>
         {% endif %}
         <tr>
             <th>Dump</th>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -15,10 +15,7 @@
     <h2><a href="../../../">TaskTiger</a> – <a href="../">{{ queue }} ({{ state }})</a></h2>
 
     <table class="metrics table table-striped table-bordered">
-        <thead>
-
-        </thead>
-        <tbody class="searchable">
+        <tbody>
         <tr>
             <th>id</th>
             <td>{{ task_data.id }}</td>
@@ -64,10 +61,7 @@
         <h3>Executions</h3>
         {% for execution_dumped, traceback, execution_integrations, execution in executions_dumped %}
             <table class="metrics table table-striped table-bordered">
-                <thead>
-
-                </thead>
-                <tbody class="searchable">
+                <tbody>
                 <tr>
                     <th>exception name</th>
                     <td>{{ execution.exception_name }}</td>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <th>Time Last Queued</th>
-            <td>{{ task_data.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+            <td>{{ task.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
         </tr>
         <tr>
             <th>Dump</th>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -38,6 +38,18 @@
                 <td>{{ task.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
             </tr>
         {% endif %}
+        {% if "unique" in task_data %}
+        <tr>
+            <th>Unique</th>
+            <td>{{ task_data.unique}}</td>
+        </tr>
+        {% endif %}
+        {% if "unique_key" in task_data %}
+        <tr>
+            <th>Unique Key</th>
+            <td>{{ task_data.unique_key}}</td>
+        </tr>
+        {% endif %}
         <tr>
             <th>Dump</th>
             <td>

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -1,39 +1,128 @@
 {% extends 'admin/index.html' %}
+
+{% block head %}
+    {{ super() }}
+    <style type="text/css">
+        th {
+            width: 1px;
+            white-space: nowrap
+        }
+    </style>
+{% endblock %}
+
 {% block body %}
 
-<h2><a href="../../../">TaskTiger</a> – <a href="../">{{ queue }} ({{ state }})</a></h2>
+    <h2><a href="../../../">TaskTiger</a> – <a href="../">{{ queue }} ({{ state }})</a></h2>
 
-<pre>{{ task_dumped }}</pre>
-{% if integrations %}
-    <p>Links:</p>
-    <ul>
-    {% for name, url in integrations %}
-        <li><a href="{{ url }}">{{ name }}</a></li>
-    {% endfor %}
-    </ul>
-{% endif %}
-{% if executions_dumped %}
-<p>Executions:</p>
+    <table class="metrics table table-striped table-bordered">
+        <thead>
 
-    <ul>
+        </thead>
+        <tbody class="searchable">
+        <tr>
+            <th>id</th>
+            <td>{{ task_data.id }}</td>
+        </tr>
+        <tr>
+            <th>func</th>
+            <td>{{ task_data.func }}</td>
+        </tr>
+        <tr>
+            <th>args</th>
+            <td>{{ task_data.args }}</td>
+        </tr>
+        <tr>
+            <th>kwargs</th>
+            <td>{{ task_data.kwargs }}</td>
+        </tr>
+        <tr>
+            <th>time last queued</th>
+            <td>{{ task_data.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+        </tr>
+        <tr>
+            <th>dump</th>
+            <td>
+                <details>
+                    <summary>Show/Hide</summary>
+                    <div>
+                        <pre>{{ task_data_dumped }}</pre>
+                    </div>
+                </details>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+    {% if integrations %}
+        <p>Links:</p>
+        <ul>
+            {% for name, url in integrations %}
+                <li><a href="{{ url }}">{{ name }}</a></li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+    {% if executions_dumped %}
+        <h3>Executions</h3>
+        {% for execution_dumped, traceback, execution_integrations, execution in executions_dumped %}
+            <table class="metrics table table-striped table-bordered">
+                <thead>
 
-        {% for execution_dumped, traceback, execution_integrations in executions_dumped %}
-
-        <li><pre>{{ execution_dumped }}
-
-{{ traceback }}</pre>
-        </li>
-            {% if execution_integrations %}
-                <ul>
-                {% for name, url in execution_integrations %}
-                    <li><a href="{{ url }}">{{ name }}</a></li>
-                {% endfor %}
-                </ul>
-            {% endif %}
+                </thead>
+                <tbody class="searchable">
+                <tr>
+                    <th>exception name</th>
+                    <td>{{ execution.exception_name }}</td>
+                </tr>
+                <tr>
+                    <th>host</th>
+                    <td>{{ execution.host }}</td>
+                </tr>
+                <tr>
+                    <th>success</th>
+                    <td>{{ execution.success }}</td>
+                </tr>
+                <tr>
+                    <th>time failed</th>
+                    <td>{{ execution.time_failed.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+                </tr>
+                <tr>
+                    <th>time started</th>
+                    <td>{{ execution.time_started.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+                </tr>
+                <tr>
+                    <th>execution integrations</th>
+                    <td>
+                        <ul>
+                            {% for name, url in execution_integrations %}
+                                <li><a href="{{ url }}">{{ name }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <th>traceback</th>
+                    <td>
+                        <details>
+                            <summary>Show/Hide</summary>
+                            <div>
+                                <pre>{{ traceback }}</pre>
+                            </div>
+                        </details>
+                    </td>
+                </tr>
+                <tr>
+                    <th>dump</th>
+                    <td>
+                        <details>
+                            <summary>Show/Hide</summary>
+                            <div>
+                                <pre>{{ execution_dumped }}</pre>
+                            </div>
+                        </details>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
         {% endfor %}
-
-    </ul>
-
-{% endif %}
+    {% endif %}
 
 {% endblock %}

--- a/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
+++ b/tasktiger_admin/templates/tasktiger_admin/tasktiger_task_detail.html
@@ -32,10 +32,12 @@
             <th>Kwargs</th>
             <td>{{ task_data.kwargs }}</td>
         </tr>
-        <tr>
-            <th>Time Last Queued</th>
-            <td>{{ task.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
-        </tr>
+        {% if task.time_last_queued %}
+            <tr>
+                <th>Time Last Queued</th>
+                <td>{{ task.time_last_queued.strftime("%Y-%m-%d %H:%M:%S") }}</td>
+            </tr>
+        {% endif %}
         <tr>
             <th>Dump</th>
             <td>

--- a/tasktiger_admin/views.py
+++ b/tasktiger_admin/views.py
@@ -99,18 +99,13 @@ class TaskTigerView(BaseView):
             self.integration_config.get('INTEGRATION_LINKS', []), task, None
         )
 
-        task_data_converted = convert_keys_to_datetime(
-            task.data, ['time_last_queued']
-        )
-
         return self.render(
             'tasktiger_admin/tasktiger_task_detail.html',
             queue=queue,
             state=state,
-            task_data=task_data_converted,
-            task_data_dumped=json.dumps(
-                task_data_converted, indent=2, sort_keys=True, default=str
-            ),
+            task=task,
+            task_data=task.data,
+            task_data_dumped=json.dumps(task.data, indent=2, sort_keys=True),
             executions_dumped=reversed(executions_dumped),
             integrations=integrations,
         )

--- a/tasktiger_admin/views.py
+++ b/tasktiger_admin/views.py
@@ -111,7 +111,7 @@ class TaskTigerView(BaseView):
             task_data_dumped=json.dumps(
                 task_data_converted, indent=2, sort_keys=True, default=str
             ),
-            executions_dumped=executions_dumped,
+            executions_dumped=reversed(executions_dumped),
             integrations=integrations,
         )
 


### PR DESCRIPTION
Closes https://github.com/closeio/tasktiger-admin/issues/14

So far I put the conversion from float to datetime in the view.py. Ideally, it would be great if that was done in tasktiger itself (`from_id()` https://github.com/closeio/tasktiger/blob/d1d05095cd46f34cde21840f2e1e17c6262c9b91/tasktiger/task.py#L420) but that would probably mean breaking the API, and not sure if worth it. Interestingly, other function that return Tasks already do float to datetime conversions, so there is a bit of inconsistency `tasks_from_queue()` https://github.com/closeio/tasktiger/blob/d1d05095cd46f34cde21840f2e1e17c6262c9b91/tasktiger/task.py#L480

![Screenshot 2021-04-12 at 12 11 48](https://user-images.githubusercontent.com/3979716/114379680-5f804a00-9b89-11eb-8eff-280a9ea6558c.png)
