### PR TITLE
Fix path of version file in autorelease action

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import re
 
 from setuptools import setup
 
-VERSION_FILE = "tasktiger/__init__.py"
+VERSION_FILE = "tasktiger_admin/__init__.py"
 with open(VERSION_FILE, encoding="utf8") as fd:
     version = re.search(r'__version__ = ([\'"])(.*?)\1', fd.read()).group(2)
 


### PR DESCRIPTION
I missed this when copy/pasting from tasktiger.